### PR TITLE
Create Event schema file and configure replication key

### DIFF
--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -18,13 +18,6 @@ class KlaviyoStream(RESTStream):
     """Klaviyo stream class."""
 
     url_base = "https://a.klaviyo.com/api"
-
-    # OR use a dynamic url_base:
-    # @property
-    # def url_base(self) -> str:
-    #     """Return the API URL root, configurable via tap settings."""
-    #     return self.config["api_url"]
-
     records_jsonpath = "$[data][*]"
     next_page_token_jsonpath = "$[links].next"
 

--- a/tap_klaviyo/schemas/event.json
+++ b/tap_klaviyo/schemas/event.json
@@ -1,0 +1,83 @@
+{
+    "properties": {
+        "name": {
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "id": {
+            "description": "The event ID",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "type": {
+            "description": "The event type",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "datetime": {
+            "description": "Event timestamp in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.mmmmmm)",
+            "format": "date-time",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "attributes": {
+            "properties": {
+                "metric_id": {
+                    "description": "The metric ID",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "profile_id": {
+                    "description": "Profile ID of the associated profile, if available",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "timestamp": {
+                    "description": "Event timestamp in seconds",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "event_properties": {
+                    "description": "Event properties, can include attribution data, identifiers and extra properties",
+                    "type": [
+                        "null",
+                        "object"
+                    ]
+                },
+                "datetime": {
+                    "description": "Event timestamp in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.mmmmmm)",
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uuid": {
+                    "description": "A unique identifier for the event, this can be used as a cursor in pagination",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": [
+                "object",
+                "null"
+            ]
+        }
+    }
+}

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -8,11 +8,7 @@ from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_klaviyo.client import KlaviyoStream
 
-# TODO: Delete this is if not using json files for schema definition
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
-# TODO: - Override `UsersStream` and `GroupsStream` with your own stream definition.
-#       - Copy-paste as many times as needed to create multiple stream types.
-
 
 class EventsStream(KlaviyoStream):
     """Define custom stream."""
@@ -20,41 +16,8 @@ class EventsStream(KlaviyoStream):
     name = "events"
     path = "/events"
     primary_keys = ["id"]
-    replication_key = None
-    # TODO: Finish building out all properties
-    schema = th.PropertiesList(
-        th.Property("name", th.StringType),
-        th.Property(
-            "id",
-            th.StringType,
-            description="The event ID",
-        ),
-        th.Property(
-            "type",
-            th.StringType,
-            description="The event type",
-        ),
-        th.Property(
-            "attributes",
-            th.ObjectType(
-                th.Property(
-                    "metric_id",
-                    th.StringType,
-                    description="The metric ID"
-                ),
-                th.Property(
-                    "timestamp",
-                    th.IntegerType,
-                    description="Event timestamp in seconds"
-                ),
-                th.Property(
-                    "datetime",
-                    th.DateTimeType,
-                    description="Event timestamp in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.mmmmmm)"
-                ),
-            ),
-        ),
-    ).to_dict()
+    replication_key = "datetime"
+    schema_filepath = SCHEMAS_DIR / "event.json"
 
     def get_url_params(
         self,
@@ -70,6 +33,7 @@ class EventsStream(KlaviyoStream):
         Returns:
             A dictionary of URL query parameters.
         """
+
         params: dict = {
             **self.base_url_params,
         }
@@ -77,10 +41,15 @@ class EventsStream(KlaviyoStream):
         if next_page_token:
             params["page[cursor]"] = next_page_token
 
-        # TODO: Convert this to a config var
-        params["filter"] = "greater-than(datetime,2023-03-15T00:00:00Z)"
+        if self.replication_key:
+            filter_timestamp = self.get_starting_timestamp(context)
+            params["filter"] = f"greater-than(datetime,{filter_timestamp})"
 
         return params
+
+    def post_process(self, row: dict, context: dict | None = None) -> dict | None:
+        row["datetime"] = row["attributes"]["datetime"]
+        return row
 
 # TODO: Change to CampaignsStream
 class GroupsStream(KlaviyoStream):


### PR DESCRIPTION
- Convert the schema definition into a schema file so it can support jsonschema patternProperties - this makes it possible to import response objects with variable key names
- Set a replication key for the event stream and reference it when getting the query parameters