### PR TITLE
feat: Increase schemas page size

### DIFF
--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -46,6 +46,7 @@ class KlaviyoStream(RESTStream):
 
     url_base = "https://a.klaviyo.com/api"
     records_jsonpath = "$[data][*]"
+    max_page_size = None
 
     @property
     def authenticator(self) -> APIKeyAuthenticator:
@@ -101,4 +102,6 @@ class KlaviyoStream(RESTStream):
 
             params["filter"] = f"greater-than({self.replication_key},{filter_timestamp})"
 
+        if self.max_page_size:
+            params["page[size]"] = self.max_page_size
         return params

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -90,6 +90,7 @@ class ProfilesStream(KlaviyoStream):
     primary_keys = ["id"]
     replication_key = "updated"
     schema_filepath = SCHEMAS_DIR / "profiles.json"
+    max_page_size = 100
 
     def post_process(
         self,
@@ -98,6 +99,15 @@ class ProfilesStream(KlaviyoStream):
     ) -> dict | None:
         row["updated"] = row["attributes"]["updated"]
         return row
+
+    def get_url_params(
+        self,
+        context: dict | None,
+        next_page_token: ParseResult | None,
+    ) -> dict[str, t.Any]:
+        url_params = super().get_url_params(context, next_page_token)
+        url_params["page[size]"] = self.max_page_size
+        return url_params
 
     @property
     def is_sorted(self) -> bool:

--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -100,15 +100,6 @@ class ProfilesStream(KlaviyoStream):
         row["updated"] = row["attributes"]["updated"]
         return row
 
-    def get_url_params(
-        self,
-        context: dict | None,
-        next_page_token: ParseResult | None,
-    ) -> dict[str, t.Any]:
-        url_params = super().get_url_params(context, next_page_token)
-        url_params["page[size]"] = self.max_page_size
-        return url_params
-
     @property
     def is_sorted(self) -> bool:
         return True
@@ -165,6 +156,7 @@ class ListPersonStream(KlaviyoStream):
     replication_key = None
     parent_stream_type = ListsStream
     schema_filepath = SCHEMAS_DIR / "listperson.json"
+    max_page_size = 1000
 
     def post_process(self, row: dict, context: dict) -> dict | None:
         row["list_id"] = context["list_id"]


### PR DESCRIPTION
This pull request increases the `profiles` and `listperson` page sizes to optimize the use of the maximum page size allowed for each one, thereby reducing the number of requests during sync.

The default for `profiles` is 20 and for `listperson` is 10.
https://developers.klaviyo.com/en/docs/apis_comparison_chart#comparison-chart-v1v2-and-corresponding-new-api-endpoints

- References:
https://developers.klaviyo.com/en/reference/get_list_relationships_profiles
https://developers.klaviyo.com/en/reference/get_profiles

```
### listperson
| INFO     | tap-klaviyo.listperson | Beginning full_table sync of 'listperson'
| INFO     | singer_sdk.helpers.jsonpath | JSONPath $[data][*] match count: 1000 

### profiles
| INFO     | tap-klaviyo.profiles | Beginning incremental sync of 'profiles'
| INFO     | singer_sdk.helpers.jsonpath | JSONPath $[data][*] match count: 100
```