### PR TITLE
Schema updates

### DIFF
--- a/tap_klaviyo/schemas/campaigns.json
+++ b/tap_klaviyo/schemas/campaigns.json
@@ -15,6 +15,27 @@
                 "null"
             ]
         },
+        "relationships": {
+            "description": "The relationships associated with the campaign",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "links": {
+            "description": "The relationships associated with the campaign",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "filter": {
+            "description": "The relationships associated with the campaign",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
         "attributes": {
             "properties": {
                 "name": {
@@ -28,6 +49,34 @@
                     "description": "The campaign type",
                     "type": [
                         "string",
+                        "null"
+                    ]
+                },
+                "audiences": {
+                    "description": "The audiences associated with the campaign",
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "send_options": {
+                    "description": "The send options associated with the campaign",
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "tracking_options": {
+                    "description": "The tracking options associated with the campaign",
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "send_strategy": {
+                    "description": "The send strategy associated with the campaign",
+                    "type": [
+                        "array",
                         "null"
                     ]
                 },

--- a/tap_klaviyo/schemas/event.json
+++ b/tap_klaviyo/schemas/event.json
@@ -34,9 +34,10 @@
             "type": [
                 "null",
                 "object"
-            ],
-            "attributes": {
-                "properties": {
+            ]
+        },
+        "attributes": {
+            "properties": {
                 "profile_id": {
                     "description": "Profile ID of the associated profile, if available",
                     "type": [

--- a/tap_klaviyo/schemas/event.json
+++ b/tap_klaviyo/schemas/event.json
@@ -32,19 +32,11 @@
         "links": {
             "description": "links",
             "type": [
-                "null",
                 "object"
             ]
         },
         "attributes": {
             "properties": {
-                "profile_id": {
-                    "description": "Profile ID of the associated profile, if available",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "timestamp": {
                     "description": "Event timestamp in seconds",
                     "type": [
@@ -76,7 +68,7 @@
                 }
             },
             "included": {
-                "description": "included",
+                "description": "",
                 "type": [
                     "null",
                     "array"

--- a/tap_klaviyo/schemas/event.json
+++ b/tap_klaviyo/schemas/event.json
@@ -1,11 +1,5 @@
 {
     "properties": {
-        "name": {
-            "type": [
-                "string",
-                "null"
-            ]
-        },
         "id": {
             "description": "The event ID",
             "type": [
@@ -28,15 +22,21 @@
                 "null"
             ]
         },
-        "attributes": {
-            "properties": {
-                "metric_id": {
-                    "description": "The metric ID",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
+        "relationships": {
+            "description": "Event relationships",
+            "type": [
+                "null",
+                "object"
+            ]
+        },
+        "links": {
+            "description": "links",
+            "type": [
+                "null",
+                "object"
+            ],
+            "attributes": {
+                "properties": {
                 "profile_id": {
                     "description": "Profile ID of the associated profile, if available",
                     "type": [
@@ -73,6 +73,13 @@
                         "null"
                     ]
                 }
+            },
+            "included": {
+                "description": "included",
+                "type": [
+                    "null",
+                    "array"
+                ]
             },
             "type": [
                 "object",

--- a/tap_klaviyo/schemas/flows.json
+++ b/tap_klaviyo/schemas/flows.json
@@ -10,6 +10,20 @@
                 "string"
             ]
         },
+        "relationships": {
+            "description": "this",
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "links": {
+            "description": "this",
+            "type": [
+                "null",
+                "string"
+            ]
+        },
         "attributes": {
             "properties": {
                 "name": {

--- a/tap_klaviyo/schemas/flows.json
+++ b/tap_klaviyo/schemas/flows.json
@@ -11,17 +11,16 @@
             ]
         },
         "relationships": {
-            "description": "this",
+            "description": "",
             "type": [
                 "null",
-                "string"
+                "object"
             ]
         },
         "links": {
-            "description": "this",
+            "description": "",
             "type": [
-                "null",
-                "string"
+                "object"
             ]
         },
         "attributes": {

--- a/tap_klaviyo/schemas/lists.json
+++ b/tap_klaviyo/schemas/lists.json
@@ -15,6 +15,20 @@
                 "null"
             ]
         },
+        "relationships": {
+            "description": "Relationships to other resources that are related to this list",
+            "type": [
+                "object",
+                "null"
+            ]
+        },
+        "links": {
+            "description": "Relationships to other resources that are related to this list",
+            "type": [
+                "object",
+                "null"
+            ]
+        },
         "attributes": {
             "properties": {
                 "name": {
@@ -24,7 +38,13 @@
                         "null"
                     ]
                 },
-
+                "opt_in_process": {
+                    "description": "The method by which contacts are added to the list",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "created": {
                     "description": "Date and time when the list was created, in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.mmmmmm)",
                     "format": "date-time",

--- a/tap_klaviyo/schemas/metrics.json
+++ b/tap_klaviyo/schemas/metrics.json
@@ -15,6 +15,19 @@
                 "null"
             ]
         },
+        "relationships": {
+            "description": "Event relationships",
+            "type": [
+                "null",
+                "object"
+            ]
+        },
+        "links": {
+            "description": "links",
+            "type": [
+                "object"
+            ]
+        },
         "attributes": {
             "properties": {
                 "name": {
@@ -67,20 +80,6 @@
                             "description": "The category of the integration",
                             "type": [
                                 "string",
-                                "null"
-                            ]
-                        },
-                        "object": {
-                            "description": "The object of the integration",
-                            "type": [
-                                "object",
-                                "null"
-                            ]
-                        },
-                        "key": {
-                            "description": "The object of the integration",
-                            "type": [
-                                "object",
                                 "null"
                             ]
                         }

--- a/tap_klaviyo/schemas/metrics.json
+++ b/tap_klaviyo/schemas/metrics.json
@@ -40,6 +40,13 @@
                         "null"
                     ]
                 },
+                "links": {
+                    "description": "Links related to the metric",
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                },
                 "integration": {
                     "properties": {
                         "id": {
@@ -60,6 +67,20 @@
                             "description": "The category of the integration",
                             "type": [
                                 "string",
+                                "null"
+                            ]
+                        },
+                        "object": {
+                            "description": "The object of the integration",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "key": {
+                            "description": "The object of the integration",
+                            "type": [
+                                "object",
                                 "null"
                             ]
                         }

--- a/tap_klaviyo/schemas/profiles.json
+++ b/tap_klaviyo/schemas/profiles.json
@@ -19,8 +19,27 @@
                 "null"
             ]
         },
+        "relationships": {
+            "description": "Relationships to other resources",
+            "type": [
+                "object"
+            ]
+        },
+        "links": {
+            "description": "Relationships to other resources",
+            "type": [
+                "object"
+            ]
+        },
         "attributes": {
             "properties": {
+                "anonymous_id": {
+                    "description": "A unique identify set by klaviyo to identify the profile",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "email": {
                     "description": "Individual's email address",
                     "type": [
@@ -163,6 +182,13 @@
                         },
                         "timezone": {
                             "description": "Time zone name. We recommend using time zones from the IANA Time Zone Database.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "ip": {
+                            "description": "Location's associated IP address",
                             "type": [
                                 "string",
                                 "null"

--- a/tap_klaviyo/schemas/profiles.json
+++ b/tap_klaviyo/schemas/profiles.json
@@ -20,26 +20,20 @@
             ]
         },
         "relationships": {
-            "description": "Relationships to other resources",
+            "description": "",
             "type": [
+                "null",
                 "object"
             ]
         },
         "links": {
-            "description": "Relationships to other resources",
+            "description": "",
             "type": [
                 "object"
             ]
         },
         "attributes": {
             "properties": {
-                "anonymous_id": {
-                    "description": "A unique identify set by klaviyo to identify the profile",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "email": {
                     "description": "Individual's email address",
                     "type": [
@@ -188,10 +182,10 @@
                             ]
                         },
                         "ip": {
-                            "description": "Location's associated IP address",
+                            "description": "IP address",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ]
                         }
                     },

--- a/tap_klaviyo/schemas/templates.json
+++ b/tap_klaviyo/schemas/templates.json
@@ -21,6 +21,13 @@
                 "null"
             ]
         },
+        "links": {
+            "description": "Links",
+            "type": [
+                "object",
+                "null"
+            ]
+        },
         "attributes": {
             "properties": {
                 "company_id": {


### PR DESCRIPTION
Resolves #72 and addresses some other missing fields along the way. See a list of the errors of missing fields I collected from the logs after fixing the schema issue with `events`.

Curiously, some of the missing fields do not appear in the 2023-10-15 API revision docs, nor do I see them in the latest revision docs. Those which did not appear I removed. This included `profiles.attributes.anonymous_id`,`metrics.attributes.integration.object',` and `'metrics.attributes.integration.key`

```
Properties ('type', 'attributes.audiences', 'attributes.send_options', 'attributes.tracking_options', 'attributes.send_strategy', 'relationships', 'links', 'filter') were present in the 'campaigns' stream but not found in catalog schema. Ignoring. 
Properties ('relationships', 'links') were present in the 'flows' stream but not found in catalog schema. Ignoring. 
Properties ('type', 'attributes.opt_in_process', 'relationships', 'links') were present in the 'lists' stream but not found in catalog schema. Ignoring.
Properties ('type', 'attributes.integration.object', 'attributes.integration.key', 'links') were present in the 'metrics' stream but not found in catalog schema. Ignoring.
Properties ('attributes.anonymous_id', 'attributes.location.ip', 'relationships', 'links') were present in the 'profiles' stream but not found in catalog schema. Ignoring.
Properties ('links',) were present in the 'templates' stream but not found in catalog schema. Ignoring.
```
