### PR TITLE
feat: prevent future events

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -22,6 +22,12 @@ plugins:
       value: '2024-02-15'
     - name: start_date
       value: '2000-01-01'
+    - name: max_retries
+      value: 5
+    - name: backoff_factor
+      value: 2
+    - name: retry_statuses
+      value: [400]
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/tap_klaviyo/client.py
+++ b/tap_klaviyo/client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from urllib.parse import parse_qsl
 
 from singer_sdk.authenticators import APIKeyAuthenticator
+from singer_sdk.exceptions import RetriableAPIError
 from singer_sdk.pagination import BaseHATEOASPaginator
 from singer_sdk.streams import RESTStream
 
@@ -75,6 +76,24 @@ class KlaviyoStream(RESTStream):
         if "revision" in self.config:
             headers["revision"] = self.config.get("revision")
         return headers
+
+    def validate_response(self, response: requests.Response) -> None:
+        if not response.ok and response.status_code in self.config.get("retry_statuses", {}):
+            error_message = (
+                f"Retryable error {response.status_code} {response.reason} "
+                f"for URL {response.url}"
+            )
+            raise RetriableAPIError(error_message)
+        super().validate_response(response)
+
+    def backoff_max_tries(self) -> int:
+        return int(self.config.get("max_retries", 3))
+
+    def backoff_wait_generator(self) -> t.Generator[float, None, None]:
+        backoff_factor = float(self.config.get("backoff_factor", 2))
+        max_tries = self.backoff_max_tries()
+        for attempt in range(max_tries):
+            yield backoff_factor * (2**attempt)
 
     def get_new_paginator(self) -> BaseHATEOASPaginator:
         return KlaviyoPaginator()


### PR DESCRIPTION
We observed rare case instances of Klaviyo API returning events way in the future (events API).
Those events will update the state to the future as well, meaning that every future call will fail because a `greater-than` filter in the API call isn't allowed.

This PR is a suggestion that would eliminate the issue by filtering out future events.
Feel free to suggest alternative approaches.



Example of a payload queried on 2024-04-12. Note that datetime (which is the Event's stream replication key) is 2025-04-21:

```
 {
            "type": "event",
            "id": "xxx",
            "attributes": {
                "timestamp": 1745246922,
                "event_properties": {
                    "utm_medium": "xxx",
                    "os": "Windows",
                    "initial_page_path": "/",
                    "browser": "Chrome",
                    "page": "xxx",
                    "utm_source": "xxx",
                    "rfsn": "xxx",
                    "$event_id": "1745246922"
                },
                "datetime": "2025-04-21T14:48:42+00:00",
                "uuid": "xxx"
            },
            "relationships": {
                "profile": {
                    "data": {
                        "type": "profile",
                        "id": "xxx"
                    },
                    "links": {
                        "self": "https://a.klaviyo.com/api/events/xxx/relationships/profile/",
                        "related": "https://a.klaviyo.com/api/events/xxx/profile/"
                    }
                },
                "metric": {
                    "data": {
                        "type": "metric",
                        "id": "xxx"
                    },
                    "links": {
                        "self": "https://a.klaviyo.com/api/events/xxx/relationships/metric/",
                        "related": "https://a.klaviyo.com/api/events/xxx/metric/"
                    }
                }
            },
            "links": {
                "self": "https://a.klaviyo.com/api/events/xxx/"
            }
        }
    ],
    "links": {
        "self": "https://a.klaviyo.com/api/events?sort=datetime&filter=greater-than%28datetime%2C2025-04-14+02%3A39%3A06%2B00%3A00%29",
        "next": null,
        "prev": null
    }
```