### PR TITLE
fix: Insufficient primary keys for `listperson` stream

### DIFF
--- a/tap_klaviyo/streams.py
+++ b/tap_klaviyo/streams.py
@@ -194,7 +194,7 @@ class ListPersonStream(KlaviyoStream):
 
     name = "listperson"
     path = "/lists/{list_id}/relationships/profiles/"
-    primary_keys = ["id"]
+    primary_keys = ["list_id", "id"]
     replication_key = None
     parent_stream_type = ListsStream
     max_page_size = 1000

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,5 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
-from unittest import TestCase
-
 from singer_sdk.testing import get_tap_test_class
 
 from tap_klaviyo import streams
@@ -19,28 +17,20 @@ TestTapKlaviyo = get_tap_test_class(
 )
 
 
-class TestPrimaryKeys(TestCase):
+def test_relationship_and_series_report_primary_keys() -> None:
     """Validate primary keys that prevent merge collisions."""
-
-    def test_relationship_and_series_report_primary_keys(self) -> None:
-        self.assertEqual(streams.ListPersonStream.primary_keys, ["list_id", "id"])
-        self.assertEqual(
-            streams.SegmentSeriesReportStream.primary_keys,
-            [
-                "report_name",
-                "segment_id",
-                "date",
-                "statistic_name",
-            ],
-        )
-        self.assertEqual(
-            streams.FlowSeriesReportStream.primary_keys,
-            [
-                "report_name",
-                "flow_id",
-                "flow_message_id",
-                "send_channel",
-                "date",
-                "statistic_name",
-            ],
-        )
+    assert streams.ListPersonStream.primary_keys == ["list_id", "id"]  # noqa: S101
+    assert streams.SegmentSeriesReportStream.primary_keys == [  # noqa: S101
+        "report_name",
+        "segment_id",
+        "date",
+        "statistic_name",
+    ]
+    assert streams.FlowSeriesReportStream.primary_keys == [  # noqa: S101
+        "report_name",
+        "flow_id",
+        "flow_message_id",
+        "send_channel",
+        "date",
+        "statistic_name",
+    ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 
 from singer_sdk.testing import get_tap_test_class
 
+from tap_klaviyo import streams
 from tap_klaviyo.tap import TapKlaviyo
 
 SAMPLE_CONFIG = {
@@ -14,3 +15,22 @@ TestTapKlaviyo = get_tap_test_class(
     tap_class=TapKlaviyo,
     config=SAMPLE_CONFIG,
 )
+
+
+def test_relationship_and_series_report_primary_keys():
+    """Validate primary keys that prevent merge collisions."""
+    assert streams.ListPersonStream.primary_keys == ["list_id", "id"]
+    assert streams.SegmentSeriesReportStream.primary_keys == [
+        "report_name",
+        "segment_id",
+        "date",
+        "statistic_name",
+    ]
+    assert streams.FlowSeriesReportStream.primary_keys == [
+        "report_name",
+        "flow_id",
+        "flow_message_id",
+        "send_channel",
+        "date",
+        "statistic_name",
+    ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,7 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
+from unittest import TestCase
+
 from singer_sdk.testing import get_tap_test_class
 
 from tap_klaviyo import streams
@@ -17,20 +19,28 @@ TestTapKlaviyo = get_tap_test_class(
 )
 
 
-def test_relationship_and_series_report_primary_keys():
+class TestPrimaryKeys(TestCase):
     """Validate primary keys that prevent merge collisions."""
-    assert streams.ListPersonStream.primary_keys == ["list_id", "id"]
-    assert streams.SegmentSeriesReportStream.primary_keys == [
-        "report_name",
-        "segment_id",
-        "date",
-        "statistic_name",
-    ]
-    assert streams.FlowSeriesReportStream.primary_keys == [
-        "report_name",
-        "flow_id",
-        "flow_message_id",
-        "send_channel",
-        "date",
-        "statistic_name",
-    ]
+
+    def test_relationship_and_series_report_primary_keys(self) -> None:
+        self.assertEqual(streams.ListPersonStream.primary_keys, ["list_id", "id"])
+        self.assertEqual(
+            streams.SegmentSeriesReportStream.primary_keys,
+            [
+                "report_name",
+                "segment_id",
+                "date",
+                "statistic_name",
+            ],
+        )
+        self.assertEqual(
+            streams.FlowSeriesReportStream.primary_keys,
+            [
+                "report_name",
+                "flow_id",
+                "flow_message_id",
+                "send_channel",
+                "date",
+                "statistic_name",
+            ],
+        )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,6 @@
 
 from singer_sdk.testing import get_tap_test_class
 
-from tap_klaviyo import streams
 from tap_klaviyo.tap import TapKlaviyo
 
 SAMPLE_CONFIG = {
@@ -15,22 +14,3 @@ TestTapKlaviyo = get_tap_test_class(
     tap_class=TapKlaviyo,
     config=SAMPLE_CONFIG,
 )
-
-
-def test_relationship_and_series_report_primary_keys() -> None:
-    """Validate primary keys that prevent merge collisions."""
-    assert streams.ListPersonStream.primary_keys == ["list_id", "id"]  # noqa: S101
-    assert streams.SegmentSeriesReportStream.primary_keys == [  # noqa: S101
-        "report_name",
-        "segment_id",
-        "date",
-        "statistic_name",
-    ]
-    assert streams.FlowSeriesReportStream.primary_keys == [  # noqa: S101
-        "report_name",
-        "flow_id",
-        "flow_message_id",
-        "send_channel",
-        "date",
-        "statistic_name",
-    ]


### PR DESCRIPTION
## Summary

This updates the `listperson` stream primary key from `["id"]` to
`["list_id", "id"]`.

`listperson` is a many-to-many relationship stream between Klaviyo Lists and
Profiles. A single profile can belong to multiple lists, so profile `id` alone
is not unique for this stream.

## Problem

With the old primary key:

```python
primary_keys = ["id"]